### PR TITLE
run gvim in foreground mode

### DIFF
--- a/spec_cleaner/rpmcleaner.py
+++ b/spec_cleaner/rpmcleaner.py
@@ -43,6 +43,9 @@ class RpmSpecCleaner:
         self.inline = inline
         self.diff = diff
         self.diff_prog = diff_prog
+        #run gvim(diff) in foreground mode
+        if self.diff_prog.startswith("gvim") and not " -f" in self.diff_prog:
+            self.diff_prog += " -f"
         self.reg = RegexpSingle(specfile)
         self.fin = open(self.specfile)
 


### PR DESCRIPTION
--diff-prog gvim will show a broken file, because as gvim forks out, the
temporary file got removed on spec-cleaner exit. This forces a
foreground mode for everything started on gvim ...

References: https://github.com/openSUSE/spec-cleaner/issues/7
