### PR TITLE
%{_docdir} path should be %{_datadir}/doc/packages

### DIFF
--- a/spec_cleaner/rpmsection.py
+++ b/spec_cleaner/rpmsection.py
@@ -136,7 +136,7 @@ class Section(object):
         re_datadir = re.compile('%{_prefix}/share([/\s$])')
         re_mandir = re.compile('%{_datadir}/man([/\s$])')
         re_infodir = re.compile('%{_datadir}/info([/\s$])')
-        re_docdir = re.compile('%{_datadir}/doc([/\s$])')
+        re_docdir = re.compile('%{_datadir}/doc/packages([/\s$])')
 
         # few hardcoded things
         line = line.replace('/etc/init.d/', '%{_initddir}/')


### PR DESCRIPTION
My spec was fixing doc installation by

mv  %{_datadir}/doc/%{name}  %{_docdir}/%{name}

and spec-cleaner changed that "mv" to a NOP :-) 
