### PR TITLE
Avoid using %_libexecdir

### DIFF
--- a/spec_cleaner/rpmsection.py
+++ b/spec_cleaner/rpmsection.py
@@ -131,7 +131,8 @@ class Section(object):
         """
         re_bindir = re.compile('%{_prefix}/bin([/\s$])')
         re_sbindir = re.compile('%{_prefix}/sbin([/\s$])')
-        re_libexecdir = re.compile('%{_prefix}/lib([/\s$])')
+        #NOTE(saschpe): %_libexedir on 11.1-Evergreen (x86_64) is %{_prefix}/lib64, thus rather not change it until EG is EOL:
+        #re_libexecdir = re.compile('%{_prefix}/lib([/\s$])')
         re_includedir = re.compile('%{_prefix}/include([/\s$])')
         re_datadir = re.compile('%{_prefix}/share([/\s$])')
         re_mandir = re.compile('%{_datadir}/man([/\s$])')
@@ -152,7 +153,7 @@ class Section(object):
 
         line = re_bindir.sub(r'%{_bindir}\1', line)
         line = re_sbindir.sub(r'%{_sbindir}\1', line)
-        line = re_libexecdir.sub(r'%{_libexecdir}\1', line)
+        #line = re_libexecdir.sub(r'%{_libexecdir}\1', line)
         line = re_includedir.sub(r'%{_includedir}\1', line)
         line = re_datadir.sub(r'%{_datadir}\1', line)
         line = re_mandir.sub(r'%{_mandir}\1', line)

--- a/tests/in/spec-cleaner.spec
+++ b/tests/in/spec-cleaner.spec
@@ -57,8 +57,8 @@ make DESTDIR=%{buildroot} install %{?_smp_mflags} \
 %files
 %defattr(-, root, root)
 %{_bindir}/%{name}
-%dir %{_libexecdir}/obs/
-%dir %{_libexecdir}/obs/service/
+%dir /usr/lib/obs/
+%dir %{_prefix}/lib/obs/service/
 %{_libexecdir}/obs/service/format_spec_file
 %{_libexecdir}/obs/service/format_spec_file.service
 %dir %{python_sitelib}/spec_cleaner/

--- a/tests/out/spec-cleaner.spec
+++ b/tests/out/spec-cleaner.spec
@@ -58,8 +58,8 @@ make DESTDIR=%{buildroot} install %{?_smp_mflags} \
 %files
 %defattr(-, root, root)
 %{_bindir}/%{name}
-%dir %{_libexecdir}/obs/
-%dir %{_libexecdir}/obs/service/
+%dir %{_prefix}/lib/obs/
+%dir %{_prefix}/lib/obs/service/
 %{_libexecdir}/obs/service/format_spec_file
 %{_libexecdir}/obs/service/format_spec_file.service
 %dir %{python_sitelib}/spec_cleaner/


### PR DESCRIPTION
On openSUSE-11.1-Evergreen x86_64, %_libexecdir is defined as %{_prefix}/%{_lib}, not %{_prefix}/lib. Thus, don't replace %%{_prefix}/lib until Evergreen is EOL (added a reminder note therefore).
