### PR TITLE
Fixed invalid license "later"

### DIFF
--- a/data/licenses_changes.txt
+++ b/data/licenses_changes.txt
@@ -807,3 +807,4 @@ eCos-2.0	eCos-2.0
 eCos-2.0+	eCos-2.0+
 gSOAP-1.3b	gSOAP-1.3b
 gSOAP-1.3b+	gSOAP-1.3b+
+or later	+


### PR DESCRIPTION
`GPLv3 or later` got translated to `GPL3 or later` which results in an RPMlint error that aborts the build.
