### PR TITLE
Fixed invalid license "later"

### DIFF
--- a/spec_cleaner/rpmpreamble.py
+++ b/spec_cleaner/rpmpreamble.py
@@ -313,6 +313,7 @@ class RpmPreamble(Section):
 
 
     def _fix_license(self, value):
+        value = value.replace(' or later', '+')
         # split using 'or', 'and' and parenthesis, ignore empty strings
         licenses = [a for a in re.split('(\(|\)| and | or )', value) if a != '']
 

--- a/tests/in/orlater.spec
+++ b/tests/in/orlater.spec
@@ -1,0 +1,1 @@
+License:        GPLv3 or later

--- a/tests/out/orlater.spec
+++ b/tests/out/orlater.spec
@@ -1,0 +1,20 @@
+#
+# spec file for package orlater
+#
+# Copyright (c) 2013 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+
+License:        GPL-3.0+
+


### PR DESCRIPTION
Converting `GPLv3 or later` to `GPL-3.0 or later` is not enough as it results in an RPMlint error that aborts the build. This notation seems to be common in older packages from the pre-SPDX era.