### PR TITLE
Use tox for running the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .*.swp
 .coverage
 .coveralls.yml
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ addons:
     - rpm
 
 language: python
-python:
-  - "2.7"
-  - "3.3"
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=py27
+    - python: 3.3
+      env: TOX_ENV=py33
 install:
-  - pip install python-coveralls mock
+  - pip install tox
 script:
-  - nosetests --with-coverage --cover-package=spec_cleaner --cover-inclusive
-after_success:
-  - coveralls
+  - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ matrix:
   include:
     - python: 2.7
       env: TOX_ENV=py27
-    - python: 3.3
-      env: TOX_ENV=py33
+    - python: 3.5
+      env: TOX_ENV=py35
 install:
   - pip install tox
 script:

--- a/README.md.in
+++ b/README.md.in
@@ -5,3 +5,11 @@
 
 spec-cleaner is a tool that is planned to be replacement for "osc service localrun format_spec_file".
 It is intended to provide same or better features in order for us to be able to unify all the spec files in obs.
+
+# Running the testsuite locally
+
+spec-cleaner uses tox to run the testsuite in a clean enviroment. To run the
+tests locally, do:
+
+    tox -epy27
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33
+envlist = py27,py35
 minversion = 1.6
 skipsdist = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py27,py33
+minversion = 1.6
+skipsdist = True
+
+[testenv]
+usedevelop = True
+install_command = pip install -U {opts} {packages}
+setenv = VIRTUAL_ENV={envdir}
+deps =
+    python-coveralls
+    mock
+    nose
+
+commands = nosetests --with-coverage --cover-package=spec_cleaner --cover-inclusive
+
+[testenv:venv]
+commands = {posargs}


### PR DESCRIPTION
This is useful to be able to run the tests also locally in
a clean virtualenv. Travis then uses just tox for the different
python versions.