### PR TITLE
Add --no-copyright switch to disable copyright header handling

### DIFF
--- a/spec_cleaner/__init__.py
+++ b/spec_cleaner/__init__.py
@@ -40,6 +40,8 @@ def process_args(argv):
                               help='inline the changes directly to the parsed file.')
     parser.add_argument('-m', '--minimal', action='store_true', default=False,
                         help='run in minimal mode that does not do anything intrusive (ie. just sets the Copyright)')
+    parser.add_argument('--no-copyright', action='store_true', default=False,
+                        help='don\'t handle or add a copyright header')
     output_group.add_argument('-o', '--output', default='',
                               help='specify the output file for the cleaned spec content.')
     parser.add_argument('-p', '--pkgconfig', action='store_true', default=False,
@@ -74,6 +76,7 @@ def process_args(argv):
         'diff': options.diff,
         'diff_prog': options.diff_prog,
         'minimal': options.minimal,
+        'no_copyright': options.no_copyright,
     }
 
     return options_dict

--- a/spec_cleaner/rpmcleaner.py
+++ b/spec_cleaner/rpmcleaner.py
@@ -55,6 +55,7 @@ class RpmSpecCleaner(object):
         self.diff = options['diff']
         self.diff_prog = options['diff_prog']
         self.minimal = options['minimal']
+        self.no_copyright = options['no_copyright']
         # run gvim(diff) in foreground mode
         if self.diff_prog.startswith("gvim") and " -f" not in self.diff_prog:
             self.diff_prog += " -f"
@@ -204,7 +205,8 @@ class RpmSpecCleaner(object):
 
     def run(self):
         # We always start with Copyright
-        self.current_section = RpmCopyright(self.specfile, self.minimal)
+        self.current_section = RpmCopyright(self.specfile, self.minimal,
+                                            self.no_copyright)
 
         # FIXME: we need to store the content localy and then reorder
         #        to maintain the specs all the same (eg somebody put

--- a/spec_cleaner/rpmcopyright.py
+++ b/spec_cleaner/rpmcopyright.py
@@ -14,8 +14,9 @@ class RpmCopyright(Section):
     that are still relevant. Everything else is ignored.
     """
 
-    def __init__(self, specfile, minimal):
+    def __init__(self, specfile, minimal, no_copyright):
         Section.__init__(self, specfile, minimal)
+        self.no_copyright = no_copyright
         self.copyrights = []
         self.buildrules = []
         self.my_copyright = ''
@@ -84,6 +85,8 @@ class RpmCopyright(Section):
             return
 
     def output(self, fout, newline=True, new_class=None):
+        if self.no_copyright:
+            return
         self._add_modelines()
         self._add_pkg_header()
         self._add_copyright()

--- a/tests/acceptance-tests.py
+++ b/tests/acceptance-tests.py
@@ -113,6 +113,7 @@ class TestCompare(unittest.TestCase):
                 'diff': False,
                 'diff_prog': 'vimdiff',
                 'minimal': False,
+                'no_copyright': False,
             }
             self._run_individual_test(options)
             with open(compare) as ref, open(tmp_file) as test:
@@ -127,6 +128,7 @@ class TestCompare(unittest.TestCase):
                 'diff': False,
                 'diff_prog': 'vimdiff',
                 'minimal': False,
+                'no_copyright': False,
             }
             self._run_individual_test(options)
             with open(compare) as ref, open(self.tmp_file_rerun.name) as test:
@@ -150,6 +152,7 @@ class TestCompare(unittest.TestCase):
                 'diff': False,
                 'diff_prog': 'vimdiff',
                 'minimal': True,
+                'no_copyright': False,
             }
             self._run_individual_test(options)
             with open(compare) as ref, open(tmp_file) as test:
@@ -164,10 +167,40 @@ class TestCompare(unittest.TestCase):
                 'diff': False,
                 'diff_prog': 'vimdiff',
                 'minimal': True,
+                'no_copyright': False,
             }
             self._run_individual_test(options)
             with open(compare) as ref, open(self.tmp_file_rerun.name) as test:
                 self.assertStreamEqual(ref, test)
+
+    @patch('spec_cleaner.rpmcopyright.datetime')
+    def test_no_copyright_output(self, datetime_mock):
+        datetime_mock.datetime.now.return_value = (
+            datetime.datetime(2013, 1, 1))
+        spec_str="""%check
+make check
+
+%changelog
+"""
+        tmp_file = os.path.join(self.tmp_dir, "no_copyright_test.spec")
+        out_file = os.path.join(self.tmp_dir, "no_copyright_test_out.spec")
+        with open(tmp_file, "w+") as t:
+            t.write(spec_str)
+
+        # first try to generate cleaned content from messed up
+        options = {
+            'specfile': tmp_file,
+            'output': out_file,
+            'pkgconfig': True,
+            'inline': False,
+            'diff': False,
+            'diff_prog': 'vimdiff',
+            'minimal': True,
+            'no_copyright': True,
+        }
+        self._run_individual_test(options)
+        with open(out_file) as ref, open(tmp_file) as test:
+            self.assertStreamEqual(ref, test)
 
     @patch('spec_cleaner.rpmcopyright.datetime')
     def test_inline_function(self, datetime_mock):
@@ -188,6 +221,7 @@ class TestCompare(unittest.TestCase):
             'diff': False,
             'diff_prog': 'vimdiff',
             'minimal': False,
+            'no_copyright': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -208,6 +242,7 @@ class TestCompare(unittest.TestCase):
             'diff': False,
             'diff_prog': 'gvimdiff',
             'minimal': False,
+            'no_copyright': False,
         }
         self._run_individual_test(options)
 
@@ -228,5 +263,6 @@ class TestCompare(unittest.TestCase):
             'diff': True,
             'diff_prog': 'gvimdiff',
             'minimal': False,
+            'no_copyright': False,
         }
         self._run_individual_test(options)


### PR DESCRIPTION
When using the new "--no-copyright" switch, the handling
(adding/modifying) the copyright header is disabled.
This is useful if you just want to create a diff for spec files without
having a copyright header yet.