### PR TITLE
Exclude %qmake5_install from bracketing

### DIFF
--- a/data/excludes-bracketing.txt
+++ b/data/excludes-bracketing.txt
@@ -82,6 +82,7 @@ preun
 py_compile
 qmake
 qmake5
+qmake5_install
 reconfigure_fonts_[^\s]*
 requires_[^\s]*
 restart_on_update

--- a/tests/in/excludes-bracketing.spec
+++ b/tests/in/excludes-bracketing.spec
@@ -81,6 +81,7 @@
 %py_compile
 %qmake
 %qmake5
+%qmake5_install
 %reconfigure_fonts_[^\s]*
 %requires_[^\s]*
 %restart_on_update

--- a/tests/out-minimal/excludes-bracketing.spec
+++ b/tests/out-minimal/excludes-bracketing.spec
@@ -108,6 +108,7 @@
 %py_compile
 %qmake
 %qmake5
+%qmake5_install
 %reconfigure_fonts_[^\s]*
 %requires_[^\s]*
 %restart_on_update

--- a/tests/out/excludes-bracketing.spec
+++ b/tests/out/excludes-bracketing.spec
@@ -109,6 +109,7 @@ make %{?_smp_mflags} DESTDIR=%{buildroot} install
 %py_compile
 %qmake
 %qmake5
+%qmake5_install
 %reconfigure_fonts_[^\s]*
 %requires_[^\s]*
 %restart_on_update


### PR DESCRIPTION
Exclude %qmake5_install from bracketing (fixes #123)