### PR TITLE
Whitespace option

### DIFF
--- a/spec_cleaner/__init__.py
+++ b/spec_cleaner/__init__.py
@@ -54,6 +54,8 @@ def process_args(argv):
                         help='convert dependencies to their tex() counterparts, requires verification of the output afterwards.')
     parser.add_argument('-v', '--version', action='version', version=__version__,
                         help='show package version and exit')
+    parser.add_argument('-k', '--keep-space', action='store_true',
+                        help='keep empty lines in preamble intact.')
 
     # print help if there is no argument
     if len(argv) < 1:
@@ -86,6 +88,7 @@ def process_args(argv):
         'perl': options.perl,
         'tex': options.tex,
         'cmake': options.cmake,
+        'keep_space': options.keep_space,
     }
 
     return options_dict

--- a/spec_cleaner/rpmpackage.py
+++ b/spec_cleaner/rpmpackage.py
@@ -12,7 +12,7 @@ class RpmPackage(RpmPreamble):
     def add(self, line):
         # The first line (%package) should always be added and is different
         # from the lines we handle in RpmPreamble.
-        if not self.previous_line:
+        if self.previous_line is None:
             Section.add(self, line)
             return
         # If the package is lang package we add here comment about the lang

--- a/tests/acceptance-tests.py
+++ b/tests/acceptance-tests.py
@@ -36,6 +36,7 @@ class TestCompare(object):
         self.tex_dir = self._get_tex_dir()
         self.perl_dir = self._get_perl_dir()
         self.cmake_dir = self._get_cmake_dir()
+        self.keep_space_dir = self._get_keep_space_dir()
         self.minimal_fixtures_dir = self._get_minimal_fixtures_dir()
         self.tmp_dir = tempfile.mkdtemp()
         self.tmp_file_rerun = tempfile.NamedTemporaryFile()
@@ -100,6 +101,12 @@ class TestCompare(object):
         """
         return os.path.join(os.getcwd(), 'tests/cmake/')
 
+    def _get_keep_space_dir(self):
+        """
+        Return path for output files used by keep_space tests
+        """
+        return os.path.join(os.getcwd(), 'tests/keep-space/')
+
     def _get_fixtures_dir(self):
         """
         Return path for representative output specs
@@ -154,6 +161,7 @@ class TestCompare(object):
             'tex': False,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -175,6 +183,7 @@ class TestCompare(object):
             'tex': False,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -203,6 +212,7 @@ class TestCompare(object):
             'tex': False,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -224,6 +234,7 @@ class TestCompare(object):
             'tex': False,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -247,6 +258,31 @@ class TestCompare(object):
             'tex': False,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
+        }
+        self._run_individual_test(options)
+        with open(compare) as ref, open(tmp_file) as test:
+            self.assertStreamEqual(ref, test)
+
+    def test_keep_space_output(self):
+        test = 'fixme-with-space.spec'
+        infile = os.path.join(self.input_dir, test)
+        compare = os.path.join(self.keep_space_dir, test)
+        tmp_file = os.path.join(self.tmp_dir, test)
+
+        options = {
+            'specfile': infile,
+            'output': tmp_file,
+            'pkgconfig': True,
+            'inline': False,
+            'diff': False,
+            'diff_prog': 'vimdiff',
+            'minimal': False,
+            'no_copyright': True,
+            'tex': False,
+            'perl': False,
+            'cmake': False,
+            'keep_space': True,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -270,6 +306,7 @@ class TestCompare(object):
             'tex': False,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -294,6 +331,7 @@ class TestCompare(object):
             'tex': False,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -315,6 +353,7 @@ class TestCompare(object):
             'tex': False,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
 
@@ -335,6 +374,7 @@ class TestCompare(object):
             'tex': False,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
 
@@ -356,6 +396,7 @@ class TestCompare(object):
             'tex': True,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -379,6 +420,7 @@ class TestCompare(object):
             'tex': False,
             'perl': True,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:
@@ -402,6 +444,7 @@ class TestCompare(object):
             'tex': True,
             'perl': False,
             'cmake': False,
+            'keep_space': False,
         }
         self._run_individual_test(options)
         with open(compare) as ref, open(tmp_file) as test:

--- a/tests/acceptance-tests.py
+++ b/tests/acceptance-tests.py
@@ -265,7 +265,10 @@ class TestCompare(object):
             self.assertStreamEqual(ref, test)
 
     def test_keep_space_output(self):
-        test = 'fixme-with-space.spec'
+        for test in ('fixme-with-space.spec', 'keep-condition-ordering.spec'):
+            self.check_keep_space_output(test)
+
+    def check_keep_space_output(self, test):
         infile = os.path.join(self.input_dir, test)
         compare = os.path.join(self.keep_space_dir, test)
         tmp_file = os.path.join(self.tmp_dir, test)

--- a/tests/in/fixme-with-space.spec
+++ b/tests/in/fixme-with-space.spec
@@ -1,0 +1,5 @@
+Requires: abcd
+Requires: efgh
+
+PreReq:   abcd
+PreReq:   efgh

--- a/tests/keep-space/fixme-with-space.spec
+++ b/tests/keep-space/fixme-with-space.spec
@@ -1,0 +1,8 @@
+Requires:       abcd
+Requires:       efgh
+
+# FIXME: use proper Requires(pre/post/preun/...)
+PreReq:         abcd
+PreReq:         efgh
+
+%changelog

--- a/tests/keep-space/keep-condition-ordering.spec
+++ b/tests/keep-space/keep-condition-ordering.spec
@@ -1,0 +1,21 @@
+
+%define root %{version}
+%if %{?xyz}
+%define foobar foobar
+%endif
+%define complexthing %{root}-complex-%{?foobar}baz
+
+%if %{?abc}
+%define ahoj babi
+%bcond_without hamster
+%endif
+
+%global test somethingelse
+%if 0%{?suse_version} > 1230
+%bcond_without systemd
+%else
+%bcond_with    systemd
+%endif
+%bcond_with self_hosting
+
+%changelog

--- a/tests/out-minimal/fixme-with-space.spec
+++ b/tests/out-minimal/fixme-with-space.spec
@@ -1,0 +1,6 @@
+Requires:       abcd
+Requires:       efgh
+PreReq:         abcd
+PreReq:         efgh
+
+%changelog

--- a/tests/out/fixme-with-space.spec
+++ b/tests/out/fixme-with-space.spec
@@ -1,0 +1,7 @@
+Requires:       abcd
+Requires:       efgh
+# FIXME: use proper Requires(pre/post/preun/...)
+PreReq:         abcd
+PreReq:         efgh
+
+%changelog


### PR DESCRIPTION
This introduces the capability to retain empty lines in the preamble section. They are treated same as comments, IOW, empty lines attach to the top of the nearest non-empty, non-comment line.

This allows users to separate sections in preamble by empty lines, without spec-cleaner messing up their stuff.