### PR TITLE
Add Development groups for Rust

### DIFF
--- a/data/allowed_groups.txt
+++ b/data/allowed_groups.txt
@@ -36,6 +36,7 @@ Development/Languages/Perl
 Development/Languages/PHP
 Development/Languages/Python
 Development/Languages/Ruby
+Development/Languages/Rust
 Development/Languages/Scheme
 Development/Languages/Tcl
 Development/Libraries/C and C++
@@ -49,6 +50,7 @@ Development/Libraries/Parallel
 Development/Libraries/Perl
 Development/Libraries/PHP
 Development/Libraries/Python
+Development/Libraries/Rust
 Development/Libraries/Tcl
 Development/Libraries/X11
 Development/Libraries/YaST


### PR DESCRIPTION
These groups are going to be used with the [upcoming Rust packaging](https://pagure.io/fedora-rust/rust2rpm/pull-request/46) being worked on.

