### PR TITLE
Add "--copyright-year" command-line flag.

### DIFF
--- a/spec_cleaner/__init__.py
+++ b/spec_cleaner/__init__.py
@@ -7,6 +7,7 @@
 import os
 import sys
 import argparse
+from datetime import datetime
 
 from .rpmexception import RpmWrongArgs, RpmException
 from .rpmcleaner import RpmSpecCleaner
@@ -46,6 +47,8 @@ def process_args(argv):
                         help='do not convert variables bracketing (%%{macro}) and keep it as it was on the input')
     parser.add_argument('--no-copyright', action='store_true',
                         help='do not include official SUSE copyright hear and just keep what is present')
+    parser.add_argument('--copyright-year', metavar='YYYY', type=int, default=datetime.now().year,
+                        help='year to insert into the copyright header when re-generating it')
     output_group.add_argument('-o', '--output', default='',
                               help='specify the output file for the cleaned spec content.')
     parser.add_argument('-p', '--pkgconfig', action='store_true',
@@ -88,6 +91,7 @@ def process_args(argv):
         'minimal': options.minimal,
         'no_curlification': options.no_curlification,
         'no_copyright': options.no_copyright,
+        'copyright_year': options.copyright_year,
         'perl': options.perl,
         'tex': options.tex,
         'cmake': options.cmake,

--- a/spec_cleaner/rpmcopyright.py
+++ b/spec_cleaner/rpmcopyright.py
@@ -17,6 +17,7 @@ class RpmCopyright(Section):
     def __init__(self, options):
         Section.__init__(self, options)
         self.no_copyright = options['no_copyright']
+        self.year = options['copyright_year']
         self.copyrights = []
         self.buildrules = []
         self.my_copyright = ''
@@ -29,8 +30,7 @@ class RpmCopyright(Section):
 #'''.format(specname))
 
     def _create_default_copyright(self):
-        year = datetime.date.today().year
-        self.my_copyright = '# Copyright (c) {0} SUSE LINUX GmbH, Nuernberg, Germany.'.format(year)
+        self.my_copyright = '# Copyright (c) {0} SUSE LINUX GmbH, Nuernberg, Germany.'.format(self.year)
 
     def _add_copyright(self):
         self._create_default_copyright()

--- a/tests/acceptance-tests.py
+++ b/tests/acceptance-tests.py
@@ -12,14 +12,6 @@ from nose.tools import raises
 from spec_cleaner import RpmException
 from spec_cleaner import RpmSpecCleaner
 
-
-class NewDate(datetime.date):
-    @classmethod
-    def today(cls):
-        return cls(2013, 1, 1)
-
-datetime.date = NewDate
-
 class TestCompare(object):
 
     """
@@ -34,6 +26,7 @@ class TestCompare(object):
         'minimal': False,
         'no_curlification': False,
         'no_copyright': True,
+        'copyright_year': 2013,
         'tex': False,
         'perl': False,
         'cmake': False,


### PR DESCRIPTION
The --copyright-year=YYYY flag allows users to choose the year spec-cleaner
will use in the re-generated copyright header. This is useful for people who
want to have that attribution match the year of the latest entry in the
accompanying *.changes file. If unspecified, the value defaults to the current
year, like before.