### PR TITLE
excludes-bracketing: don't bracket %ghc_lib_build_without_haddock

### DIFF
--- a/data/excludes-bracketing.txt
+++ b/data/excludes-bracketing.txt
@@ -42,6 +42,7 @@ ghc_check_bootstrap
 ghc_fix_dynamic_rpath
 ghc_fix_rpath
 ghc_lib_build
+ghc_lib_build_without_haddock
 ghc_lib_install
 ghc_pkg_recache
 ghost


### PR DESCRIPTION
That macro is a function.