### PR TITLE
Replace 'http' with 'https' in URL

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 addopts = -vv --cov=spec_cleaner
 python_files = *-tests.py
 testpaths = tests
+markers =
+    webtest: marks tests that need an internet connection

--- a/tests/in/url_https.spec
+++ b/tests/in/url_https.spec
@@ -1,0 +1,38 @@
+Name:           url_http_sudo
+Summary:        Replace http with https if possible
+License:        GPL-2.0
+Url:            http://sudo.ws
+
+%package google-http
+Summary: Http google.com
+Url: http://google.com
+
+%package google-https
+Summary: Https google.com
+Url: https://google.com
+
+%package with www
+Summary: www.google.com
+Url: www.google.com
+
+%package without www
+Summary: google.com
+Url: google.com
+
+%package non-existing
+Summary: This page doesn't exist
+Url: http://thishopefullydoesnexist.com
+
+# Certificate
+
+%package expired
+Summary: Expired certificate
+Url: http://expired.badssl.com/
+
+%package wronghost
+Summary: Wrong host
+Url: http://wrong.host.badssl.com/
+
+%package null
+Summary: Null cipher suite
+Url: http://null.badssl.com/

--- a/tests/out-minimal/url_https.spec
+++ b/tests/out-minimal/url_https.spec
@@ -1,0 +1,39 @@
+Name:           url_http_sudo
+Summary:        Replace http with https if possible
+License:        GPL-2.0-only
+URL:            http://sudo.ws
+
+%package google-http
+Summary:        Http google.com
+URL:            http://google.com
+
+%package google-https
+Summary:        Https google.com
+URL:            https://google.com
+
+%package with www
+Summary:        www.google.com
+URL:            www.google.com
+
+%package without www
+Summary:        google.com
+URL:            google.com
+
+%package non-existing
+Summary:        This page doesn't exist
+URL:            http://thishopefullydoesnexist.com
+# Certificate
+
+%package expired
+Summary:        Expired certificate
+URL:            http://expired.badssl.com/
+
+%package wronghost
+Summary:        Wrong host
+URL:            http://wrong.host.badssl.com/
+
+%package null
+Summary:        Null cipher suite
+URL:            http://null.badssl.com/
+
+%changelog

--- a/tests/out/spec-cleaner.spec
+++ b/tests/out/spec-cleaner.spec
@@ -23,7 +23,7 @@ Release:        0
 Summary:        .spec file cleaner
 License:        BSD-3-Clause
 Group:          Development/Tools/Other
-URL:            http://github.com/openSUSE/spec-cleaner
+URL:            https://github.com/openSUSE/spec-cleaner
 Source0:        https://github.com/openSUSE/%{name}/archive/%{name}-%{version}.tar.gz
 BuildRequires:  python
 Requires:       python-base

--- a/tests/web/url_https.spec
+++ b/tests/web/url_https.spec
@@ -1,0 +1,39 @@
+Name:           url_http_sudo
+Summary:        Replace http with https if possible
+License:        GPL-2.0-only
+URL:            https://sudo.ws
+
+%package google-http
+Summary:        Http google.com
+URL:            https://google.com
+
+%package google-https
+Summary:        Https google.com
+URL:            https://google.com
+
+%package with www
+Summary:        www.google.com
+URL:            https://www.google.com
+
+%package without www
+Summary:        google.com
+URL:            https://google.com
+
+%package non-existing
+Summary:        This page doesn't exist
+URL:            http://thishopefullydoesnexist.com
+# Certificate
+
+%package expired
+Summary:        Expired certificate
+URL:            http://expired.badssl.com/
+
+%package wronghost
+Summary:        Wrong host
+URL:            http://wrong.host.badssl.com/
+
+%package null
+Summary:        Null cipher suite
+URL:            http://null.badssl.com/
+
+%changelog


### PR DESCRIPTION
Use 'https' in URL if a https website is reachable (closes #246). Also
update the old tests, add a new test (url_https.spec) for this feature
and mark this test as a webtest so we can ignore it while we don't
have an internet connection. Add docstrings for acceptance-tests.py.